### PR TITLE
[Fix] Disable/Enable Bundle ID button

### DIFF
--- a/js/interface.js
+++ b/js/interface.js
@@ -1106,14 +1106,14 @@ function getSubmissions() {
 
 function disableForm() {
   $(formInputSelectors.join(',')).prop('disabled', true);
-  $('[data-push-save], [data-app-store-save], [data-app-store-build]')
+  $('[data-push-save], [data-app-store-save], [data-app-store-build], [change-bundleid]')
     .addClass('disabled')
     .prop('disabled', true);
 }
 
 function enableForm() {
   $(formInputSelectors.join(',')).prop('disabled', false);
-  $('[data-push-save], [data-app-store-save], [data-app-store-build]')
+  $('[data-push-save], [data-app-store-save], [data-app-store-build], [change-bundleid]')
     .removeClass('disabled')
     .prop('disabled', false);
 }


### PR DESCRIPTION
- Issue found during Alpha Testing. The bundle ID should now be disabled or enabled depending on the organization type.